### PR TITLE
fix: applyCaring동시성 문제해결

### DIFF
--- a/src/main/java/com/github/backend/repository/ServiceApplyRepository.java
+++ b/src/main/java/com/github/backend/repository/ServiceApplyRepository.java
@@ -6,7 +6,10 @@ import com.github.backend.web.entity.UserEntity;
 import com.github.backend.web.entity.custom.CustomUserDetails;
 import com.github.backend.web.entity.enums.CareStatus;
 import com.github.backend.web.entity.enums.MateCareStatus;
+import jakarta.persistence.LockModeType;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -23,11 +26,6 @@ public interface ServiceApplyRepository extends JpaRepository<CareEntity, Long >
     
     Integer countByCareStatus(CareStatus careStatus);
 
-    @Query("SELECT c.mate FROM CareEntity c " +
-          "INNER JOIN c.mate m " +
-          "WHERE m.mateCid = :mateCid")
-    Optional<CareEntity> findByMateCid(Long mateCid);
-
-
-    CareEntity findCareEntityByContent(String content);
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<CareEntity> findById(Long Id);
 }

--- a/src/test/java/com/github/backend/service/MateServiceTest.java
+++ b/src/test/java/com/github/backend/service/MateServiceTest.java
@@ -1,0 +1,34 @@
+package com.github.backend.service;
+
+import com.github.backend.repository.MateCareHistoryRepository;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class MateServiceTest {
+
+    @Autowired
+    private MateCareHistoryRepository mateCareHistoryRepository;
+
+    @Autowired
+    private MateService mateService;
+
+    @Test
+    void applyService() throws InterruptedException {
+        System.out.println("테스트 실행");
+
+        for(int i = 1; i<= 2; i++) {
+            long finalI = i;
+            new Thread(()-> {
+                System.out.println(finalI+"번째 쓰레드가 실행되고있습니다.");
+                mateService.applyCaring(5L, finalI);
+            }).start();
+        }
+
+        int count = mateCareHistoryRepository.countByCare_CareCid(5l);
+
+        System.out.println(count);
+    }
+}


### PR DESCRIPTION
- 순차적으로 동일한 careCid로 도움을 지원했을 경우 CareStatus에 대한 고려없이 모두 다 지원가능하도록 했던 문제 수정함 (*선착순 1명만 지원가능하도록 해야했는데, 순차적으로 동일한 careCid에 지원했을때 마지막으로 지원한 mate가 care엔티티에 저장되는 문제가 있었음)
- 동시에 동일한 careCid를 지원했을때, 1명만 지원되도록 하기위해 lock을 설정함.
- 동시성 문제 확인위해 테스트코드 작성